### PR TITLE
Update location of DirectiveLocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "coveralls": "^2.11.14",
     "eslint": "^3.8.0",
     "eslint-config-google": "^0.6.0",
-    "graphql": "^0.10.1",
+    "graphql": "^0.12.0",
     "mocha": "^3.1.2",
     "nyc": "^8.3.1"
   }

--- a/src/directives/currency.js
+++ b/src/directives/currency.js
@@ -1,5 +1,5 @@
 import { GraphQLString } from 'graphql';
-import { DirectiveLocation } from 'graphql/type/directives';
+import { DirectiveLocation } from 'graphql/language/directiveLocation';
 import { GraphQLCustomDirective } from '../custom';
 
 import numeral from 'numeral';

--- a/src/directives/date.js
+++ b/src/directives/date.js
@@ -1,5 +1,5 @@
 import { GraphQLString, GraphQLBoolean } from 'graphql';
-import { DirectiveLocation } from 'graphql/type/directives';
+import { DirectiveLocation } from 'graphql/language/directiveLocation';
 import { GraphQLCustomDirective } from '../custom';
 import { _ } from 'lodash';
 

--- a/src/directives/number.js
+++ b/src/directives/number.js
@@ -1,5 +1,5 @@
 import { GraphQLString } from 'graphql';
-import { DirectiveLocation } from 'graphql/type/directives';
+import { DirectiveLocation } from 'graphql/language/directiveLocation';
 import { GraphQLCustomDirective } from '../custom';
 
 import numeral from 'numeral';

--- a/src/directives/string.js
+++ b/src/directives/string.js
@@ -1,4 +1,4 @@
-import { DirectiveLocation } from 'graphql/type/directives';
+import { DirectiveLocation } from 'graphql/language/directiveLocation';
 import { GraphQLString, GraphQLNonNull } from 'graphql';
 import { GraphQLCustomDirective } from '../custom';
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 import { GraphQLCustomDirective, applySchemaCustomDirectives } from '../src/index';
 import { GraphQLInt, GraphQLSchema, GraphQLObjectType, GraphQLNonNull, GraphQLList, graphql, buildSchema } from 'graphql';
-import { DirectiveLocation } from 'graphql/type/directives';
+import { DirectiveLocation } from 'graphql/language/directiveLocation';
 import { createGraphQLQueryDeepObject, testEqual, testNullEqual } from './utils';
 
 import { expect } from 'chai';

--- a/test/utils.js
+++ b/test/utils.js
@@ -7,6 +7,7 @@ const DEFAULT_TEST_SCHEMA = `type Query { value(input: String): String } schema 
 
 exports.testEqual = function({ directives, query, schema, input, passServer = false, expected, done, context }) {
 
+
   let executionSchema = buildSchema(schema || DEFAULT_TEST_SCHEMA);
 
   if (!schema) {
@@ -16,14 +17,14 @@ exports.testEqual = function({ directives, query, schema, input, passServer = fa
     }
   }
 
-  executionSchema._directives = executionSchema._directives.concat(directives);
+  if (directives)
+    executionSchema._directives = executionSchema._directives.concat(directives);
 
   applySchemaCustomDirectives(executionSchema);
 
   graphql(executionSchema, query, input, context)
     .then(({data, errors }) => {
       if (errors) {
-        console.error(errors);
         throw new Error(errors);
       }
       expect(data).to.eql(expected);


### PR DESCRIPTION
DirectiveLocation moved in the latest version of Graphql.js.
This commit updates the location and fixes a test for normal execution.

Without this, upgrading to Graphqljs 0.12.0 would result in `TypeError: Cannot read property 'FIELD' of undefined` as DirectiveLocation would be undefined which is the error seen in issue #15.