### PR TITLE
fix(custom): fix resolve function doesnt exist

### DIFF
--- a/src/custom.js
+++ b/src/custom.js
@@ -34,7 +34,11 @@ function resolveWithDirective(resolve, source, directive, context, info) {
     args[arg.name.value] = arg.value.value;
   }
 
-  return directiveConfig.resolve(resolve, source, args, context, info);
+  if (directiveConfig && directiveConfig.resolve) {
+    return directiveConfig.resolve(resolve, source, args, context, info);
+  }
+
+  return resolve();
 }
 
 /**


### PR DESCRIPTION
Not all directives have an explicit resolver, for example the skip directive. In some cases, the custom handler also receives native directives written by GraphQL, and we want it to support them as well.